### PR TITLE
Add remote cursor style check

### DIFF
--- a/elements/AAC-850m6/element_actions/AAN-850mw/run.js
+++ b/elements/AAC-850m6/element_actions/AAN-850mw/run.js
@@ -12,6 +12,21 @@ function(instance, properties, context) {
     this.isHandlingRemoteEvent = false;
     this.remoteBlockIds = new Set();
 
+    // Ensure remote cursor styles are added only once
+    if (!document.getElementById('remote-cursor-style')) {
+        const style = document.createElement('style');
+        style.id = 'remote-cursor-style';
+        style.textContent = `
+            .remote-cursor {
+                position: absolute;
+                width: 2px;
+                background: red;
+                z-index: 1000;
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
     const createWebSocket = () => {
         const socket = new WebSocket('wss://free.blr2.piesocket.com/v3/1?api_key=4yn77E9zUO31vzW9fSgn6y66C96vpaZRYPJXO72l&notify_self=1');
 


### PR DESCRIPTION
## Summary
- add style setup for remote cursor, ensuring it's added only once

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c289e630c8327ae4cea92a3457813